### PR TITLE
#4 avoid fat vc

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		F0B454B02BBEC35A00405276 /* RepoDetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */; };
 		F0B454B22BBEDA2D00405276 /* SearchRepoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */; };
 		F0B454B52BBFA8A300405276 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B42BBFA8A300405276 /* Constant.swift */; };
+		F0B454B72BBFB0CD00405276 /* GitHubReposDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B62BBFB0CD00405276 /* GitHubReposDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -79,6 +80,7 @@
 		F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDetailAPI.swift; sourceTree = "<group>"; };
 		F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoAPI.swift; sourceTree = "<group>"; };
 		F0B454B42BBFA8A300405276 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		F0B454B62BBFB0CD00405276 /* GitHubReposDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubReposDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,6 +138,7 @@
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
 				BFD945E2244DC5E80012785A /* MainViewController.swift */,
+				F0B454B62BBFB0CD00405276 /* GitHubReposDataSource.swift */,
 				BF0A658C244F2A3B00280FA6 /* DetailViewController.swift */,
 				BFD945E4244DC5E80012785A /* Main.storyboard */,
 				BFD945E7244DC5EB0012785A /* Assets.xcassets */,
@@ -357,6 +360,7 @@
 				F0B454B52BBFA8A300405276 /* Constant.swift in Sources */,
 				F0B454A82BBE4EE600405276 /* Collection+Extension.swift in Sources */,
 				F0B454AB2BBEAADF00405276 /* APIClient.swift in Sources */,
+				F0B454B72BBFB0CD00405276 /* GitHubReposDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		F0B454AE2BBEC32C00405276 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AD2BBEC32C00405276 /* APIRequest.swift */; };
 		F0B454B02BBEC35A00405276 /* RepoDetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */; };
 		F0B454B22BBEDA2D00405276 /* SearchRepoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */; };
+		F0B454B52BBFA8A300405276 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B42BBFA8A300405276 /* Constant.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -77,6 +78,7 @@
 		F0B454AD2BBEC32C00405276 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDetailAPI.swift; sourceTree = "<group>"; };
 		F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoAPI.swift; sourceTree = "<group>"; };
+		F0B454B42BBFA8A300405276 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				F0B454AC2BBEAAE700405276 /* API */,
+				F0B454B32BBFA88800405276 /* Constant */,
 				F0B454A92BBE4EF200405276 /* Extension */,
 				BFD945DE244DC5E80012785A /* AppDelegate.swift */,
 				BFD945E0244DC5E80012785A /* SceneDelegate.swift */,
@@ -177,6 +180,14 @@
 				F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		F0B454B32BBFA88800405276 /* Constant */ = {
+			isa = PBXGroup;
+			children = (
+				F0B454B42BBFA8A300405276 /* Constant.swift */,
+			);
+			path = Constant;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -343,6 +354,7 @@
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				F0B454B22BBEDA2D00405276 /* SearchRepoAPI.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
+				F0B454B52BBFA8A300405276 /* Constant.swift in Sources */,
 				F0B454A82BBE4EE600405276 /* Collection+Extension.swift in Sources */,
 				F0B454AB2BBEAADF00405276 /* APIClient.swift in Sources */,
 			);

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		F0B454AB2BBEAADF00405276 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AA2BBEAADF00405276 /* APIClient.swift */; };
 		F0B454AE2BBEC32C00405276 /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AD2BBEC32C00405276 /* APIRequest.swift */; };
 		F0B454B02BBEC35A00405276 /* RepoDetailAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */; };
+		F0B454B22BBEDA2D00405276 /* SearchRepoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -75,6 +76,7 @@
 		F0B454AA2BBEAADF00405276 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		F0B454AD2BBEC32C00405276 /* APIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequest.swift; sourceTree = "<group>"; };
 		F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoDetailAPI.swift; sourceTree = "<group>"; };
+		F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +174,7 @@
 				F0B454AA2BBEAADF00405276 /* APIClient.swift */,
 				F0B454AD2BBEC32C00405276 /* APIRequest.swift */,
 				F0B454AF2BBEC35A00405276 /* RepoDetailAPI.swift */,
+				F0B454B12BBEDA2D00405276 /* SearchRepoAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				F0B454AE2BBEC32C00405276 /* APIRequest.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				F0B454B22BBEDA2D00405276 /* SearchRepoAPI.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				F0B454A82BBE4EE600405276 /* Collection+Extension.swift in Sources */,
 				F0B454AB2BBEAADF00405276 /* APIClient.swift in Sources */,

--- a/iOSEngineerCodeCheck/API/APIClient.swift
+++ b/iOSEngineerCodeCheck/API/APIClient.swift
@@ -16,20 +16,32 @@ class APIClient {
         self.baseURL = baseURL
     }
     
+    private func addQueryParameters(to url: URL, parameters: [String: Any]) -> URL? {
+        var components: URLComponents? = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        var queryItems: [URLQueryItem] = []
+        for (key, value) in parameters {
+            let stringValue: String = String(describing: value)
+            queryItems.append(URLQueryItem(name: key, value: stringValue))
+        }
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
     func send<T: APIRequest>(_ request: T, completion: @escaping (Result<T.Response, Error>) -> Void) {
+        
         let url: URL = baseURL.appendingPathComponent(request.path)
+        guard let url: URL = addQueryParameters(to: url, parameters: request.parameters ?? [:]) else {
+            completion(.failure(NSError(domain: "Invalid URL", code: -1, userInfo: nil)))
+            return
+        }
         var urlRequest: URLRequest = URLRequest(url: url)
         urlRequest.httpMethod = request.method
         urlRequest.allHTTPHeaderFields = request.headers
-        if request.method == "POST" {
-            urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: request.parameters ?? [:])
-        }
         URLSession.shared.dataTask(with: urlRequest) { data, _, error in
             guard let data = data else {
                 completion(.failure(error ?? NSError(domain: "Unknown", code: -1, userInfo: nil)))
                 return
             }
-            
             do {
                 let decoder: JSONDecoder = JSONDecoder()
                 let responseObject: T.Response = try decoder.decode(T.Response.self, from: data)

--- a/iOSEngineerCodeCheck/API/RepoDetailAPI.swift
+++ b/iOSEngineerCodeCheck/API/RepoDetailAPI.swift
@@ -44,13 +44,15 @@ struct RepoDetailResponse: Decodable {
             case owner
         }
     
-    init() {
-        language = ""
-        stargazersCount = 0
-        subscribersCount = 0
-        forksCount = 0
-        openIssuesCount = 0
-        owner = Owner()
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer = try decoder.container(keyedBy: CodingKeys.self)
+        language = try container.decodeIfPresent(String.self, forKey: .language) ?? ""
+        stargazersCount = try container.decodeIfPresent(Int.self, forKey: .stargazersCount) ?? 0
+        subscribersCount = try container.decodeIfPresent(Int.self, forKey: .subscribersCount) ?? 0
+        forksCount = try container.decodeIfPresent(Int.self, forKey: .forksCount) ?? 0
+        openIssuesCount = try container.decodeIfPresent(Int.self, forKey: .openIssuesCount) ?? 0
+        owner = try container.decodeIfPresent(Owner.self, forKey: .owner) ?? Owner(from: decoder)
+    
     }
     
 }
@@ -62,8 +64,9 @@ struct Owner: Decodable {
         case avatarUrl = "avatar_url"
     }
     
-    init() {
-        avatarUrl = ""
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer = try decoder.container(keyedBy: CodingKeys.self)
+        avatarUrl = try container.decodeIfPresent(String.self, forKey: .avatarUrl) ?? ""
     }
     
 }

--- a/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
+++ b/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
@@ -33,6 +33,11 @@ struct SearchReposResponse: Decodable {
     private enum CodingKeys: String, CodingKey {
         case items
     }
+    
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer = try decoder.container(keyedBy: CodingKeys.self)
+        items = try container.decodeIfPresent([RepoItem].self, forKey: .items) ?? []
+    }
 
 }
 
@@ -41,5 +46,10 @@ struct RepoItem: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case fullName = "full_name"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container: KeyedDecodingContainer = try decoder.container(keyedBy: CodingKeys.self)
+        fullName = try container.decodeIfPresent(String.self, forKey: .fullName) ?? ""
     }
 }

--- a/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
+++ b/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
@@ -2,8 +2,44 @@
 //  SearchRepoAPI.swift
 //  iOSEngineerCodeCheck
 //
-//  Created by Shin Toyo on 2024/04/04.
+//  Created by Shingo Toyoda on 2024/04/04.
 //  Copyright © 2024 YUMEMI Inc. All rights reserved.
 //
 
 import Foundation
+
+/// リポジトリの検索結果を取得するAPI
+struct SearchReposRequest: APIRequest {
+    typealias Response = SearchReposResponse
+    
+    let keyword: String
+    
+    var path: String {
+        return "search/repositories"
+    }
+    
+    var method: String {
+        return "GET"
+    }
+    
+    var parameters: [String: Any]? {
+        return ["q": keyword]
+    }
+}
+
+struct SearchReposResponse: Decodable {
+    let items: [RepoItem]
+    
+    private enum CodingKeys: String, CodingKey {
+        case items
+    }
+
+}
+
+struct RepoItem: Decodable {
+    let fullName: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case fullName = "full_name"
+    }
+}

--- a/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
+++ b/iOSEngineerCodeCheck/API/SearchRepoAPI.swift
@@ -1,0 +1,9 @@
+//
+//  SearchRepoAPI.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Shin Toyo on 2024/04/04.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+import Foundation

--- a/iOSEngineerCodeCheck/Constant/Constant.swift
+++ b/iOSEngineerCodeCheck/Constant/Constant.swift
@@ -8,5 +8,5 @@
 
 // 定数を管理するクラス
 class Constant {
-    static let githubAPIURL = "https://api.github.com"
+    static let githubAPIURL: String = "https://api.github.com"
 }

--- a/iOSEngineerCodeCheck/Constant/Constant.swift
+++ b/iOSEngineerCodeCheck/Constant/Constant.swift
@@ -1,0 +1,12 @@
+//
+//  Constant.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by Shingo Toyoda on 2024/04/05.
+//  Copyright © 2024 YUMEMI Inc. All rights reserved.
+//
+
+// 定数を管理するクラス
+class Constant {
+    static let githubAPIURL = "https://api.github.com"
+}

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -21,17 +21,13 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var forksLabel: UILabel!
     @IBOutlet weak var issuesLabel: UILabel!
     
-    var vc1: MainViewController?
+    var fullName: String?
         
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let vc1 = vc1, let selectedIndex = vc1.selectedIndex, let repo = vc1.githubRepos[safe: selectedIndex] else {
-            return
-        }
-        
-        titleLabel.text = repo["full_name"] as? String
-        fetchDetailFromName(of: repo["full_name"] as? String)
+        titleLabel.text = fullName
+        fetchDetailFromName(of: fullName)
         
     }
     

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -37,7 +37,10 @@ class DetailViewController: UIViewController {
         }
         let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
         let request: RepoDetailRequest = RepoDetailRequest(repositoryName: name)
-        apiClient.send(request) { result in
+        apiClient.send(request) {[weak self] result in
+            guard let self = self else {
+                return
+            }
             switch result {
             case .success(let response):
                 DispatchQueue.main.async {

--- a/iOSEngineerCodeCheck/DetailViewController.swift
+++ b/iOSEngineerCodeCheck/DetailViewController.swift
@@ -35,7 +35,7 @@ class DetailViewController: UIViewController {
         guard let name = name else {
             return
         }
-        let apiClient: APIClient = APIClient(baseURL: URL(string: "https://api.github.com")!)
+        let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
         let request: RepoDetailRequest = RepoDetailRequest(repositoryName: name)
         apiClient.send(request) { result in
             switch result {

--- a/iOSEngineerCodeCheck/GitHubReposDataSource.swift
+++ b/iOSEngineerCodeCheck/GitHubReposDataSource.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+class GitHubReposDataSource: NSObject, UITableViewDataSource {
+    private var repos: [RepoItem] = []
+
+    func update(with repos: [RepoItem]) {
+        self.repos = repos
+    }
+
+    func repo(at index: Int) -> RepoItem? {
+        guard index >= 0 && index < repos.count else {
+            return nil
+        }
+        return repos[index]
+    }
+
+    // MARK: - UITableViewDataSource
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return repos.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell = UITableViewCell()
+        let repo: RepoItem = repos[indexPath.row]
+        cell.textLabel?.text = repo.fullName
+        return cell
+    }
+}

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -38,7 +38,7 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
             return
         }
         if !keyword.isEmpty {
-            let apiClient: APIClient = APIClient(baseURL: URL(string: "https://api.github.com")!)
+            let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
             let request: SearchReposRequest = SearchReposRequest(keyword: keyword)
             apiClient.send(request) { result in
                 switch result {

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MainViewController: UITableViewController, UISearchBarDelegate {
+class MainViewController: UITableViewController {
 
     @IBOutlet weak var searchBar: UISearchBar!
     
@@ -23,40 +23,7 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
     }
-    
-    func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        return true
-    }
-    
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        task?.cancel()
-    }
-    
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchKeyword = searchBar.text
-        guard let keyword = searchKeyword else {
-            return
-        }
-        if !keyword.isEmpty {
-            let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
-            let request: SearchReposRequest = SearchReposRequest(keyword: keyword)
-            apiClient.send(request) { result in
-                switch result {
-                case .success(let response):
-                    DispatchQueue.main.async {
-                        self.githubRepos = response
-                        self.tableView.reloadData()
-                    }
-                case .failure(let error):
-                    print(error)
-                }
-            }
-        // これ呼ばなきゃAPIが叩かれない
-        task?.resume()
-        }
-        
-    }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
         if segue.identifier == "Detail" {
@@ -93,3 +60,40 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
     }
     
 }
+
+extension MainViewController: UISearchBarDelegate {
+    
+    func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
+        return true
+    }
+    
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        task?.cancel()
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchKeyword = searchBar.text
+        guard let keyword = searchKeyword else {
+            return
+        }
+        if !keyword.isEmpty {
+            let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
+            let request: SearchReposRequest = SearchReposRequest(keyword: keyword)
+            apiClient.send(request) { result in
+                switch result {
+                case .success(let response):
+                    DispatchQueue.main.async {
+                        self.githubRepos = response
+                        self.tableView.reloadData()
+                    }
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        // これ呼ばなきゃAPIが叩かれない
+        task?.resume()
+        }
+    }
+
+}
+

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -13,7 +13,6 @@ class MainViewController: UITableViewController {
     @IBOutlet weak var searchBar: UISearchBar!
     
     var githubRepos: SearchReposResponse = SearchReposResponse(items: [])
-    var task: URLSessionTask?
     var searchKeyword: String?
     var selectedIndex: Int?
     
@@ -67,10 +66,6 @@ extension MainViewController: UISearchBarDelegate {
         return true
     }
     
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        task?.cancel()
-    }
-    
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchKeyword = searchBar.text
         guard let keyword = searchKeyword else {
@@ -79,7 +74,10 @@ extension MainViewController: UISearchBarDelegate {
         if !keyword.isEmpty {
             let apiClient: APIClient = APIClient(baseURL: URL(string: Constant.githubAPIURL)!)
             let request: SearchReposRequest = SearchReposRequest(keyword: keyword)
-            apiClient.send(request) { result in
+            apiClient.send(request) {[weak self] result in
+                guard let self = self else {
+                    return
+                }
                 switch result {
                 case .success(let response):
                     DispatchQueue.main.async {
@@ -90,8 +88,6 @@ extension MainViewController: UISearchBarDelegate {
                     print(error)
                 }
             }
-        // これ呼ばなきゃAPIが叩かれない
-        task?.resume()
         }
     }
 

--- a/iOSEngineerCodeCheck/MainViewController.swift
+++ b/iOSEngineerCodeCheck/MainViewController.swift
@@ -21,13 +21,11 @@ class MainViewController: UITableViewController, UISearchBarDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        searchBar.text = "GitHubのリポジトリを検索できるよー"
+        searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
     }
     
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        // ↓こうすれば初期のテキストを消せる
-        searchBar.text = ""
         return true
     }
     


### PR DESCRIPTION
## 実装内容
### FatVCへの対処
- DetailVCのMainVCへの依存を解消
  - MainVC->DetailVCへの遷移では最低限必要なリポジトリ名のみを渡す
- 検索用のAPIクライアントを実装
  - MainVCから通信処理を切り離す
- `GithubRepoDataSource`を定義
  - MainVCからDataSourceを切り離す
- UISearchBarDelegateのメソッドはextensionに切り離して実装

### その他改修
- 定数管理を実装
  - APIのベースURLを管理
- 検索時にplaceholderを使用する
- クロージャのselfを弱参照にする

## 関連するissue
resolve #4 
## その他
